### PR TITLE
Build: add option to disable tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,4 +74,12 @@ AC_CONFIG_FILES([lksctp-tools.spec
 		src/withsctp/Makefile
 		doc/Makefile
 		libsctp.pc])
+
+# Build options
+AC_ARG_ENABLE(tests,
+	AS_HELP_STRING([--disable-tests],
+	[Build tests (default: yes)]),,
+	[enable_tests=yes])
+AM_CONDITIONAL(BUILD_TESTS, [test $enable_tests != no])
+
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,8 @@
 include $(top_srcdir)/Makefile.vars
 include $(top_srcdir)/Makefile.rules
 
-SUBDIRS = apps func_tests include lib testlib withsctp
+SUBDIRS = apps include lib testlib withsctp
+
+if BUILD_TESTS
+SUBDIRS += func_tests
+endif


### PR DESCRIPTION
Add an option to disable the build of the tests, since these require threads they might skipped on very small footprint embedded targets for space savings.

Signed-off-by: Gustavo Zacarias <gustavo@zacarias.com.ar>