### PR TITLE
Fix SCTP stream option bugs in sctp_test

### DIFF
--- a/src/apps/sctp_test.c
+++ b/src/apps/sctp_test.c
@@ -612,7 +612,17 @@ int socket_r(void)
 		fprintf(stderr, "SCTP_EVENTS: error: %d\n", error);
 		exit(1);
 	}
-
+        if (max_stream > 0) {
+        	struct sctp_initmsg initmsg;
+        	memset(&initmsg, 0, sizeof(struct sctp_initmsg));
+        	initmsg.sinit_num_ostreams = max_stream;
+                int i 
+                error = setsockopt(sk, IPPROTO_SCTP, SCTP_INITMSG, &initmsg, sizeof(struct sctp_initmsg));
+		if (error) {
+			fprintf(stderr, "SCTP_INITMSG: error: %d\n", error);
+			exit(1);
+		}
+        }
 	return sk;
 
 } /* socket_r() */

--- a/src/apps/sctp_test.c
+++ b/src/apps/sctp_test.c
@@ -616,11 +616,10 @@ int socket_r(void)
         	struct sctp_initmsg initmsg;
         	memset(&initmsg, 0, sizeof(struct sctp_initmsg));
         	initmsg.sinit_num_ostreams = max_stream;
-                int i 
                 error = setsockopt(sk, IPPROTO_SCTP, SCTP_INITMSG, &initmsg, sizeof(struct sctp_initmsg));
-		if (error) {
-			fprintf(stderr, "SCTP_INITMSG: error: %d\n", error);
-			exit(1);
+                if (error) {
+                	fprintf(stderr, "SCTP_INITMSG: error: %d\n", error);
+                	exit(1);
 		}
         }
 	return sk;

--- a/src/apps/sctp_test.c
+++ b/src/apps/sctp_test.c
@@ -616,11 +616,11 @@ int socket_r(void)
         	struct sctp_initmsg initmsg;
         	memset(&initmsg, 0, sizeof(struct sctp_initmsg));
         	initmsg.sinit_num_ostreams = max_stream;
-                error = setsockopt(sk, IPPROTO_SCTP, SCTP_INITMSG, &initmsg, sizeof(struct sctp_initmsg));
-                if (error) {
-                	fprintf(stderr, "SCTP_INITMSG: error: %d\n", error);
-                	exit(1);
-		}
+        	error = setsockopt(sk, IPPROTO_SCTP, SCTP_INITMSG, &initmsg, sizeof(struct sctp_initmsg));
+        	if (error) {
+        		fprintf(stderr, "SCTP_INITMSG: error: %d\n", error);
+        		exit(1);
+        	}
         }
 	return sk;
 


### PR DESCRIPTION
current sctp_test can send packets with multiple stream,
But we found bugs in sctp_test stream option.
if we configure multiple stream number > 10.
the sctp_test will failed when send packets.
