### PR TITLE
Add -I option to support IPv6 multihoming with 2 link local IP 

### DIFF
--- a/src/apps/sctp_test.c
+++ b/src/apps/sctp_test.c
@@ -221,9 +221,7 @@ void usage(char *argv0)
 	fprintf(stderr, "\t   2 = max\n");
 	fprintf(stderr, "\t-c testcase\n");
 	fprintf(stderr, "\t   0 = 1 byte packets.\n");
-	fprintf(stderr, "\t   1 = Sequence of following size packets.\n");
-	fprintf(stderr, "\t       (1452, 2904, 4356, 1452, 2904, 4356, ");
-	fprintf(stderr, "1452, 2904, 4356, 1452)\n");
+	fprintf(stderr, "\t   1 = Sequence of multiples of 1452 byte packets.\n");
 	fprintf(stderr, "\t       (1452 is fragmentation point for an i/f with ");
 	fprintf(stderr, "1500 as mtu.)\n");
 	fprintf(stderr, "\t   2 = 1453 byte packets.\n");

--- a/src/apps/sctp_test.c
+++ b/src/apps/sctp_test.c
@@ -171,6 +171,7 @@ int bindx_add_count = 0;
 struct sockaddr *connectx_addrs = NULL;
 int connectx_count = 0;
 int if_index = 0;
+int if_ext_index = 0;
 
 unsigned char msg[] = "012345678901234567890123456789012345678901234567890";
 
@@ -209,7 +210,8 @@ void usage(char *argv0)
 		"\t      [-m max-msgsize]\n"
 		"\t      [-L num-ports] [-S num-ports]\n"
 		"\t      [-a assoc-pattern]\n"
-		"\t      [-i interface]\n",
+		"\t      [-i interface]\n"
+		"\t      [-I ext-interface]\n",
 		argv0);
 	fprintf(stderr, "\n");
 	fprintf(stderr, "\t-a assoc_pattern in the mixed mode\n");
@@ -694,6 +696,9 @@ bindx_r(int sk, struct sockaddr *addrs, int count, int flag)
 		case AF_INET6:
 			((struct sockaddr_in6 *)sa_addr)->sin6_port =
 				htons(local_port);
+			if(if_ext_index) {
+				((struct sockaddr_in6 *)sa_addr)->sin6_scope_id = if_ext_index;
+			}
 			aptr += sizeof(struct sockaddr_in6);
 			break;
 		default:
@@ -1415,12 +1420,13 @@ main(int argc, char *argv[])
 {
 	int c;
 	char *interface = NULL;
+	char *interface_ext = NULL;
 	struct sockaddr_in *t_addr;
 	struct sockaddr_in6 *t_addr6;
 	struct sockaddr *tmp_addrs = NULL;
 	
         /* Parse the arguments.  */
-        while ((c = getopt(argc, argv, ":H:L:P:S:a:h:p:c:d:lm:sx:X:o:t:M:r:w:Di:TB:C:O:")) >= 0 ) {
+        while ((c = getopt(argc, argv, ":H:L:P:S:a:h:p:c:d:lm:sx:X:o:t:M:r:w:Di:I:TB:C:O:")) >= 0 ) {
 
                 switch (c) {
 		case 'H':
@@ -1561,6 +1567,14 @@ main(int argc, char *argv[])
 			if_index = if_nametoindex(interface);
 			if (!if_index) {
 				printf("Interface %s unknown\n", interface);
+				exit(1);
+			}
+			break;
+		case 'I':
+			interface_ext = optarg;
+			if_ext_index = if_nametoindex(interface_ext);
+			if (!if_ext_index) {
+				printf("interface_ext %s unknown\n", interface_ext);
 				exit(1);
 			}
 			break;

--- a/src/apps/sctp_test.c
+++ b/src/apps/sctp_test.c
@@ -221,8 +221,10 @@ void usage(char *argv0)
 	fprintf(stderr, "\t   2 = max\n");
 	fprintf(stderr, "\t-c testcase\n");
 	fprintf(stderr, "\t   0 = 1 byte packets.\n");
-	fprintf(stderr, "\t   1 = 1452 byte packets.\n");
-	fprintf(stderr, "\t       (fragmentation point for an i/f with ");
+	fprintf(stderr, "\t   1 = Sequence of following size packets.\n");
+	fprintf(stderr, "\t       (1452, 2904, 4356, 1452, 2904, 4356, ");
+	fprintf(stderr, "1452, 2904, 4356, 1452)\n");
+	fprintf(stderr, "\t       (1452 is fragmentation point for an i/f with ");
 	fprintf(stderr, "1500 as mtu.)\n");
 	fprintf(stderr, "\t   2 = 1453 byte packets.\n");
 	fprintf(stderr, "\t       (min. size at which fragmentation occurs\n");
@@ -235,7 +237,7 @@ void usage(char *argv0)
 	fprintf(stderr, "\t       (default max receive window size.)\n");
 	fprintf(stderr, "\t   6 = random size packets.\n");
 	fprintf(stderr, "\t   -ve value = Packets of specifed size.\n");
-	fprintf(stderr, "\t-m msgsize(1500-65515, default value 32768)\n");
+	fprintf(stderr, "\t-m max msgsize for option -c 6 (1500-65515, default value 32768)\n");
 	fprintf(stderr, "\t-x number of repeats\n");
 	fprintf(stderr, "\t-o order-pattern\n");
 	fprintf(stderr, "\t   0 = all unordered(default) \n");


### PR DESCRIPTION
    Add -I option for external interface
    As -i option used to specify the interface information
    in case of IPv6 linklocal address.
    -I is used for multihoming scenario of IPv6.
