### PR TITLE
sctp_test: fix next stream identifier calculation

### DIFF
--- a/src/apps/sctp_test.c
+++ b/src/apps/sctp_test.c
@@ -941,11 +941,11 @@ int next_stream(int state, int pattern)
 {
 	switch (pattern){
 	case STREAM_PATTERN_RANDOM:
-		state = rand() % (max_stream + 1);
+		state = rand() % (max_stream == 0 ? 1 : max_stream);
 		break;
 	case STREAM_PATTERN_SEQUENTIAL:
 		state = state + 1;
-		if (state > max_stream)
+		if (state >= max_stream)
 			state = 0;
 		break;
 	}


### PR DESCRIPTION
If max stream is set to be N, the range of stream is [0 - (N-1)].
The next_stream could return N. As a result, we had an off-by-1
situation with the stream identifier we could use.

Signed-off-by: Jianwen Ji <jijianwen@gmail.com>