### PR TITLE
lksctp-tools: improve the sctp_opt_info function

### DIFF
--- a/src/lib/opt_info.c
+++ b/src/lib/opt_info.c
@@ -53,10 +53,14 @@ sctp_opt_info(int sd, sctp_assoc_t id, int opt, void *arg, socklen_t *size)
 	case SCTP_AUTH_ACTIVE_KEY:
 	case SCTP_PEER_AUTH_CHUNKS:
 	case SCTP_LOCAL_AUTH_CHUNKS:
+	case SCTP_PR_SUPPORTED:
+	case SCTP_DEFAULT_PRINFO:
+	case SCTP_PR_ASSOC_STATUS:
 		*(sctp_assoc_t *)arg = id;
 		return getsockopt(sd, IPPROTO_SCTP, opt, arg, size);
 	default:
-		return ENOTSUP;
+		errno = ENOTSUP;
+		return -1;
 	}
 
 } /* sctp_opt_info() */


### PR DESCRIPTION
1. Add support for SCTP_PR_SUPPORTED, SCTP_DEFAULT_PRINFO
   and SCTP_PR_ASSOC_STATUS.
2. Make return value be -1 on failure, which is in accordance
   with sctp_opt_info manual page:
       " On success, sctp_opt_info returns 0 and on failure -1 is
         returned with errno set to the appropriate error code."

Signed-off-by: Jianwen Ji <jijianwen@gmail.com>