### PR TITLE
sctp_test: fix compiler warning

### DIFF
--- a/src/apps/sctp_test.c
+++ b/src/apps/sctp_test.c
@@ -256,7 +256,7 @@ void usage(char *argv0)
 	fprintf(stderr, "\t   be specified by using this argument multiple times.\n");
 	fprintf(stderr, "\t   For example, '-B 10.0.0.1 -B 20.0.0.2'.\n");
 	fprintf(stderr, "\t   In case of IPv6 linklocal address, interface name can be set in following way \n");
-	fprintf(stderr, "\t   For example, '-B fe80::f8c3:b77f:698e:4506\%eth2'.\n");
+	fprintf(stderr, "\t   For example, '-B fe80::f8c3:b77f:698e:4506%%eth2'.\n");
 	fprintf(stderr, "\t-C use the specified address(es) for connection to the\n");
 	fprintf(stderr, "\t   peer socket. Multiple addresses can be specified by\n");
 	fprintf(stderr, "\t   using this argument multiple times.\n");


### PR DESCRIPTION
Since the percent sign is used to define format specifiers,
there's a special format specifier that means "print the percent
sign" - double percent sign(%%).

sctp_test uses a single percent sign, which causes compiler warnings
every time when compiling sctp_test.c:

  sctp_test.c:259:68: warning: format ‘%e’ expects a matching ‘double’ argument

And it also causes incorrect output of by executing 'sctp_test -h':

  For example, '-B fe80::f8c3:b77f:698e:45062.083317e-317th2'.

Signed-off-by: Jianwen Ji <jijianwen@gmail.com>