### PR TITLE
tests: fix SMALL_MAXSEG

### DIFF
--- a/src/func_tests/test_sctp_sendrecvmsg.c
+++ b/src/func_tests/test_sctp_sendrecvmsg.c
@@ -60,7 +60,7 @@ int TST_CNT = 0;
 
 /* RCVBUF value, and indirectly RWND*2 */
 #define SMALL_RCVBUF 3000
-#define SMALL_MAXSEG 100
+#define SMALL_MAXSEG 500
 /* This is extra data length to ensure rwnd closes */
 #define RWND_SLOP    100
 static char *fillmsg = NULL;

--- a/src/func_tests/test_timetolive.c
+++ b/src/func_tests/test_timetolive.c
@@ -76,7 +76,7 @@ int TST_CNT = 0;
 #define SMALL_RCVBUF 3000
 
 /* MAX segment size */
-#define SMALL_MAXSEG 100
+#define SMALL_MAXSEG 500
 
 /* RWND_SLOP is the extra data that fills up the rwnd */
 #define RWND_SLOP 100


### PR DESCRIPTION
After Commit ecca8f88da5c ("sctp: set frag_point in sctp_setsockopt_maxseg
correctly") in kernel, sctp will not allow to set max_seg with a too small
value.

Now it's using SMALL_MAXSEG in func_tests, with SMALL_MAXSEG = 100,
sctp_setsockopt always returns err and causes some tests to fail.

This patch is to avoid it by defining SMALL_MAXSEG as 500 instead, 500
is a good value, as it's very close to the minimum and will not cause
the last frag's size is different from the others', which would also
lead to failure of some tests.

Signed-off-by: Xin Long <lucien.xin@gmail.com>