### PR TITLE
Allow static linkage with libsctp.a

### DIFF
--- a/src/lib/connectx.c
+++ b/src/lib/connectx.c
@@ -140,8 +140,8 @@ int sctp_connectx2(int fd, struct sockaddr *addrs, int addrcnt,
 	return __connectx(fd, addrs, addrs_size, id);
 }
 
-SYMVER(sctp_connectx3, sctp_connectx@@VERS_3)
-int sctp_connectx3(int fd, struct sockaddr *addrs, int addrcnt,
+SYMVER(sctp_connectx, sctp_connectx@@VERS_3)
+int sctp_connectx(int fd, struct sockaddr *addrs, int addrcnt,
 		      sctp_assoc_t *id)
 {
 	int addrs_size = __connectx_addrsize(addrs, addrcnt);


### PR DESCRIPTION
At the time libsctp.a does not provide sctp_connectx symbol which is forward-declared in its interface.

This PR suggests renaming sctp_connectx3 to sctp_connectx to workaround this.

We don't use pull requests anymore.  Please follow Linux netdev community patch
posting standard instead. Post your patches to linux-sctp@vger.kernel.org and
they will be very welcomed. Thanks!
