### PR TITLE
docs: update references to mailing list and website

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -913,13 +913,5 @@ Bug   473322 Sendmsg insists on msg_name (jgrimm)
 
 
 If you would like to follow the day-to-day development of the SCTP
-kernel, refer to:
-
-   http://lists.sourceforge.net/lists/listinfo/lksctp-developers
-
-Post messages for the developers (including bug reports) to
-
-   lksctp-developers@lists.sourceforge.net
-
-If you wish to participate in development, please subscribe to the
-developers' list, drop a note to lksctp-developers.
+kernel, please refer to the README file for contact information and how to
+collaborate.

--- a/INSTALL
+++ b/INSTALL
@@ -36,57 +36,23 @@ later kernel.
 
 To install/build the lksctp-tools utilities/tests do the following:
 
-1) Download and install the following binary RPMs from the lksctp sourceforge
-   website at 
-	http://sourceforge.net/project/showfiles.php?group_id=26529
-   * lksctp-tools-x.y.z-1.i386.rpm
-   * lksctp-tools-x.y.z-devel-1.i386.rpm
-   * lksctp-tools-x.y.z-doc-1.i386.rpm
-
-   lksctp-tools-x.y.z-1.i386.rpm includes 
-   * SCTP run-time library.
-   * Sample SCTP applications: sctp_darn and sctp_test.
-   * withsctp: a tool when used with existing TCP binaries replaces TCP
-               with SCTP.
-
-   lksctp-tools-x.y.z-devel-1.i386.rpm includes
-   * SCTP header file /usr/include/netinet/sctp.h
-   * SCTP man pages.
-   * Source code for sample SCTP applications.
-
-   lksctp-tools-x.y.z-doc-1.i386.rpm includes
-   * SCTP RFC's and internet drafts. 
-
-   If you want to run and play with the included sample SCTP applications or 
-   develop your own SCTP applications, you can skip the rest of the
-   instructions.
-
-   If you are interested in running the functional regression tests included
-   in the lksctp-tools package, continue with the following instructions.
-
-2) Download and install the following source RPM form the lksctp sourceforge
-   website at 
-        http://sourceforge.net/project/showfiles.php?group_id=26529
-   * lksctp-tools-x.y.z-1.src.rpm
-   This will install the lksctp-tools gzipped tarball and RPM spec file. 
-
-3) Untar the lksctp-tools directory from the gzipped tarball. This creates a 
+1) Untar the lksctp-tools directory from the gzipped tarball. This creates a 
    subdirectory called lksctp-tools-x.y.z. 
 
    Ensure you have autoconf, automake and libtool packages installed on your
    system.
 
-4) Run ./bootstrap
+2) Run ./bootstrap
 
-5) Run ./configure
+3) Run ./configure
 
-6) Run make
+4) Run make
 
-7) To run the SCTP kernel regression tests,
+5) To run the SCTP kernel regression tests,
   
    $ cd src/func_tests
    $ make v4test (regression tests for the IPv4 socket support)
    $ make v6test (regression tests for the IPv6 socket support)
 
-8) Run other SCTP test tools/applications in src/apps directory to verify the
+6) Run other SCTP test tools/applications in src/apps directory to verify the
    running SCTP.

--- a/README
+++ b/README
@@ -124,14 +124,14 @@ set of tests for the code.  We can not safely refactor major parts of
 the code without a way to find the things we break.  If you decide to
 extend the SCTP Kernel Implementation we ask that you do the following:
 
-	1) Pick an XP story.  Tell lksctp-developers@lists.sourceforge.net
+	1) Pick an XP story.  Tell linux-sctp@vger.kernel.org
 	2) Write a functional test for that XP story.  The functional
 	   test defines "DONE" for the story.
-	3) Submit the functional test as a patch on SourceForge.
+	3) Submit the functional test as a Pull Request on GitHub.
 	4) Write unit tests for any new "objects" you define.
 	5) Implement your feature.
 	6) Submit the feature and the unit tests as a separate
-	SourceForge patch.
+	GitHub Pull Request.
 	
 Look in src/func_tests and in lksctp-tests package for examples of of tests.
 Please do not submit code that fails its own tests or any of the unit tests.
@@ -156,9 +156,10 @@ The simulator makes a few simplifying assumptions...
 
 MAILING LISTS and WEB SITES
 ---------------------------
-http://www.sourceforge.net/projects/lksctp
+https://github.com/sctp/lksctp-tools/
 
-	This is the lksctp project webpage.  
+	This is the lksctp project webpage.  The wiki section contains
+	more info about it, including which RFCs it supports.
 
 linux-sctp@vger.kernel.org
 	

--- a/doc/ols.tex
+++ b/doc/ols.tex
@@ -685,7 +685,7 @@ All the code discussed in this paper is available from the lksctp
 project on Source Forge:
 
 \begin{center}
-\texttt{http://sourceforge.net/projects/lksctp/}
+\texttt{https://github.com/sctp/lksctp-tools/}
 \end{center}
 
 \begin{thebibliography}{2001}

--- a/doc/style_guide.txt
+++ b/doc/style_guide.txt
@@ -1,5 +1,5 @@
 This is the style guide for the LKSCTP Project.
-<http://www.sf.net/projects/lksctp/>
+<https://github.com/sctp/lksctp-tools//>
 
 1.0 Introduction
 

--- a/doc/template.c
+++ b/doc/template.c
@@ -31,10 +31,10 @@
  * 
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  * 
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Written or modified by: 
  *    La Monte H.P. Yarroll <piggy@acm.org>

--- a/lksctp-tools.spec.in
+++ b/lksctp-tools.spec.in
@@ -25,22 +25,14 @@
 #   Free Software Foundation, Inc., 675 Mass Ave, Cambridge,
 #   MA 02139, USA.
 
-%define lksctp_version @VERSION@
-
-# older lksctp-tools file name did not conform to RPM file naming
-# conventions
-
-%define pack_version %{lksctp_version}
-%define file_version %{lksctp_version}
-
 Summary: User-space access to Linux Kernel SCTP
 Name: @PACKAGE@
-Version: %{pack_version}
+Version: @VERSION@
 Release: 1
 License: LGPL
 Group: System Environment/Libraries
-URL: http://lksctp.sourceforge.net
-Source0: %{name}-%{file_version}.tar.gz
+URL: https://github.com/sctp/lksctp-tools/
+Source0: https://github.com/sctp/%{name}/archive/%{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 BuildRequires: gcc
 #BuildRequires: tetex, tetex-latex, tetex-xdvi, tetex-dvips
@@ -84,7 +76,7 @@ Documents pertaining to LKSCTP & SCTP in general
 - IETF RFC's & Internet Drafts
 
 %prep
-%setup -q -n %{name}-%{file_version}
+%setup -q -n %{name}-%{version}
 
 %build
 %configure --enable-shared --enable-static

--- a/src/apps/myftp.c
+++ b/src/apps/myftp.c
@@ -27,7 +27,7 @@
  *    lksctp developers <sctp-developers-list@cig.mot.com>
  * 
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Written or modified by: 
  *    Xingang Guo           <xingang.guo@intel.com>

--- a/src/apps/nagle_rcv.c
+++ b/src/apps/nagle_rcv.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/apps/nagle_snd.c
+++ b/src/apps/nagle_snd.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/apps/peel_client.c
+++ b/src/apps/peel_client.c
@@ -50,10 +50,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/apps/peel_server.c
+++ b/src/apps/peel_server.c
@@ -51,10 +51,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/apps/sctp_darn.c
+++ b/src/apps/sctp_darn.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/apps/sctp_status.c
+++ b/src/apps/sctp_status.c
@@ -20,10 +20,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/apps/sctp_test.c
+++ b/src/apps/sctp_test.c
@@ -26,10 +26,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Written or modified by:
  *   Hui Huang         <hui.huang@nokia.com>

--- a/src/apps/sctp_xconnect.c
+++ b/src/apps/sctp_xconnect.c
@@ -20,10 +20,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_1_to_1_accept_close.c
+++ b/src/func_tests/test_1_to_1_accept_close.c
@@ -40,10 +40,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_1_to_1_addrs.c
+++ b/src/func_tests/test_1_to_1_addrs.c
@@ -46,10 +46,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_1_to_1_connect.c
+++ b/src/func_tests/test_1_to_1_connect.c
@@ -34,10 +34,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release

--- a/src/func_tests/test_1_to_1_connectx.c
+++ b/src/func_tests/test_1_to_1_connectx.c
@@ -34,10 +34,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release

--- a/src/func_tests/test_1_to_1_events.c
+++ b/src/func_tests/test_1_to_1_events.c
@@ -23,10 +23,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will

--- a/src/func_tests/test_1_to_1_initmsg_connect.c
+++ b/src/func_tests/test_1_to_1_initmsg_connect.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will

--- a/src/func_tests/test_1_to_1_nonblock.c
+++ b/src/func_tests/test_1_to_1_nonblock.c
@@ -31,10 +31,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release

--- a/src/func_tests/test_1_to_1_recvfrom.c
+++ b/src/func_tests/test_1_to_1_recvfrom.c
@@ -31,10 +31,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release

--- a/src/func_tests/test_1_to_1_recvmsg.c
+++ b/src/func_tests/test_1_to_1_recvmsg.c
@@ -32,10 +32,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release

--- a/src/func_tests/test_1_to_1_rtoinfo.c
+++ b/src/func_tests/test_1_to_1_rtoinfo.c
@@ -28,10 +28,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release

--- a/src/func_tests/test_1_to_1_send.c
+++ b/src/func_tests/test_1_to_1_send.c
@@ -32,10 +32,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release

--- a/src/func_tests/test_1_to_1_sendmsg.c
+++ b/src/func_tests/test_1_to_1_sendmsg.c
@@ -39,10 +39,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release

--- a/src/func_tests/test_1_to_1_sendto.c
+++ b/src/func_tests/test_1_to_1_sendto.c
@@ -29,10 +29,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release

--- a/src/func_tests/test_1_to_1_shutdown.c
+++ b/src/func_tests/test_1_to_1_shutdown.c
@@ -30,10 +30,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release

--- a/src/func_tests/test_1_to_1_socket_bind_listen.c
+++ b/src/func_tests/test_1_to_1_socket_bind_listen.c
@@ -48,10 +48,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_1_to_1_sockopt.c
+++ b/src/func_tests/test_1_to_1_sockopt.c
@@ -50,10 +50,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  * 
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_1_to_1_threads.c
+++ b/src/func_tests/test_1_to_1_threads.c
@@ -25,10 +25,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release

--- a/src/func_tests/test_assoc_abort.c
+++ b/src/func_tests/test_assoc_abort.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_assoc_shutdown.c
+++ b/src/func_tests/test_assoc_shutdown.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_autoclose.c
+++ b/src/func_tests/test_autoclose.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_basic.c
+++ b/src/func_tests/test_basic.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_connect.c
+++ b/src/func_tests/test_connect.c
@@ -21,10 +21,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_connectx.c
+++ b/src/func_tests/test_connectx.c
@@ -21,10 +21,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_fragments.c
+++ b/src/func_tests/test_fragments.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_getname.c
+++ b/src/func_tests/test_getname.c
@@ -21,10 +21,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported given to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_inaddr_any.c
+++ b/src/func_tests/test_inaddr_any.c
@@ -25,10 +25,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_peeloff.c
+++ b/src/func_tests/test_peeloff.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_recvmsg.c
+++ b/src/func_tests/test_recvmsg.c
@@ -23,10 +23,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Written or modified by:
  *    Sridhar Samudrala		<sri@us.ibm.com>

--- a/src/func_tests/test_sctp_sendrecvmsg.c
+++ b/src/func_tests/test_sctp_sendrecvmsg.c
@@ -21,10 +21,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_sctp_sendvrecvv.c
+++ b/src/func_tests/test_sctp_sendvrecvv.c
@@ -15,10 +15,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_sockopt.c
+++ b/src/func_tests/test_sockopt.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_tcp_style.c
+++ b/src/func_tests/test_tcp_style.c
@@ -23,10 +23,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/func_tests/test_timetolive.c
+++ b/src/func_tests/test_timetolive.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/testlib/sctputil.c
+++ b/src/testlib/sctputil.c
@@ -24,10 +24,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/testlib/sctputil.h
+++ b/src/testlib/sctputil.h
@@ -25,10 +25,10 @@
  *
  * Please send any bug reports or fixes you make to the
  * email address(es):
- *    lksctp developers <lksctp-developers@lists.sourceforge.net>
+ *    lksctp developers <linux-sctp@vger.kernel.org>
  *
  * Or submit a bug report through the following website:
- *    http://www.sf.net/projects/lksctp
+ *    https://github.com/sctp/lksctp-tools/
  *
  * Any bugs reported to us we will try to fix... any fixes shared will
  * be incorporated into the next SCTP release.

--- a/src/withsctp/README
+++ b/src/withsctp/README
@@ -11,5 +11,5 @@ $ make all
 # make install
 
 This package originally written by La Monte H.P. Yarroll <piggy@acm.org>.
-To submit fixes or bug reports see lksctp.sourceforget.net.
-You can try the author or lksctp-developers@lists.sourceforget.net for support.
+To submit fixes or bug reports see https://github.com/sctp/lksctp-tools/
+You can try linux-sctp@vger.kernel.org for support.


### PR DESCRIPTION
Many places were referring to old mailing list and site hosted at sourceforge. These had moved to github and vger a long time ago. This commit updates these references.

Closes: #44

Signed-off-by: Marcelo Ricardo Leitner <marcelo.leitner@gmail.com>