### PR TITLE
zero-initialize sinfo_assoc_id in sctp_rcvmsg

### DIFF
--- a/src/lib/recvmsg.c
+++ b/src/lib/recvmsg.c
@@ -86,6 +86,11 @@ int sctp_recvmsg(int s, void *msg, size_t len, struct sockaddr *from,
 	if (!sinfo)
 		return error;
 
+	/* zero-initialize sctp_assoc_id, as the kernel always uses sctp_assoc_id > 0
+	 * and hence the caller can check for sinfo_assoc_id != 0 to determine if the kernel
+	 * actually provided a SCPT_SNDRCV cmsg below. */
+	sinfo->sinfo_assoc_id = 0;
+
 	for (cmsg = CMSG_FIRSTHDR(&inmsg); cmsg != NULL;
 				 cmsg = CMSG_NXTHDR(&inmsg, cmsg)){
 		if ((IPPROTO_SCTP == cmsg->cmsg_level) &&


### PR DESCRIPTION
sctp_rcvmsg can succesfully return either with filling the caller-provided sctp_sndrcvinfo or without.

FreeBSD seems to solve this problem by zeroing out sinfo_assoc_id before the [conditional] copying-in of sctp_sndrcvinfo from the cmsg.

This way, the caller can check for sinfo_assoc_id == 0 to detect situations where the sctp_sndrcvinfo has not been provided.

Closes: #37